### PR TITLE
Digest::Digest is deprecated

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,7 +59,7 @@ PBKDF2 objects can also be configured with the following options:
       `OpenSSL::Digest::SHA512.new`. If you use this method, take care that
       the hash object is in its just-initialized state (or that the same hash
       object with the same state is used whenever keys are generated/checked).
-    * As a string which is understood by `OpenSSL::Digest::Digest.new()`.  
+    * As a string which is understood by `OpenSSL::Digest.new()`.  
       Things like "sha1", "md5", "RIPEMD160", etc. all work fine.  If the
       string begins with the text "hmacWith" it will be stripped before
       passing it to the underlying OpenSSL library, making it possible to use

--- a/lib/pbkdf2.rb
+++ b/lib/pbkdf2.rb
@@ -95,7 +95,6 @@ class PBKDF2
       # see if the OpenSSL lib understands it
       hash = OpenSSL::Digest.new(hash)
     when OpenSSL::Digest
-    when OpenSSL::Digest::Digest
       # ok
     else
       raise TypeError, "Unknown hash type: #{hash.class}"

--- a/spec/pbkdf2_spec.rb
+++ b/spec/pbkdf2_spec.rb
@@ -59,7 +59,7 @@ describe PBKDF2, "when configuring a hash function" do
     p.hash_function.name.should == "SHA512"
   end
 
-  it "should allow setting by an instantiated object of type OpenSSL::Digest::Digest" do
+  it "should allow setting by an instantiated object of type OpenSSL::Digest::SHA512" do
     hfunc = OpenSSL::Digest::SHA512.new
     p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :hash_function=>hfunc)
     p.hash_function.name.should == "SHA512"
@@ -70,7 +70,7 @@ describe PBKDF2, "when setting a key length" do
   it "should default to the size of the hash function used" do
     %w{SHA1 SHA512 MD5}.each do |alg|
       p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :hash_function=>alg)
-      p.key_length.should == OpenSSL::Digest::Digest.new(alg).size
+      p.key_length.should == OpenSSL::Digest.new(alg).size
     end
   end
 


### PR DESCRIPTION
Use of OpenSSL::Digest::Digest has been discouraged since Ruby 1.8.7 and generates a deprecation warning on Ruby 2.1.x

See: https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51 and https://github.com/ruby/ruby/pull/446

This would necessitate a bigger version bump in the next release, as this would make the gem backwards-incompatible with clients that pass `Digest::Digest` instead of just `Digest`.
