### PR TITLE
Convert specs to RSpec 3.0.3 syntax with Transpec

### DIFF
--- a/spec/pbkdf2_spec.rb
+++ b/spec/pbkdf2_spec.rb
@@ -2,19 +2,19 @@ require File.dirname(__FILE__) + '/spec_helper.rb'
 
 describe PBKDF2, "when initializing" do
   it "should raise an ArgumentError if an unrecognized parameter is passed" do
-    lambda {PBKDF2.new(:foo=>1)}.should raise_error(ArgumentError)
+    expect {PBKDF2.new(:foo=>1)}.to raise_error(ArgumentError)
   end
 
   it "should raise an ArgumentError if a password is not set" do
-    lambda {PBKDF2.new(:salt=>"nacl", :iterations=>1000)}.should raise_error(ArgumentError)
+    expect {PBKDF2.new(:salt=>"nacl", :iterations=>1000)}.to raise_error(ArgumentError)
   end
 
   it "should raise an ArgumentError if a salt is not set" do
-    lambda {PBKDF2.new(:password=>"s33krit", :iterations=>1000)}.should raise_error(ArgumentError)
+    expect {PBKDF2.new(:password=>"s33krit", :iterations=>1000)}.to raise_error(ArgumentError)
   end
 
   it "should raise an ArgumentError if iterations is not set" do
-    lambda {PBKDF2.new(:password=>"s33krit", :salt=>"nacl")}.should raise_error(ArgumentError)
+    expect {PBKDF2.new(:password=>"s33krit", :salt=>"nacl")}.to raise_error(ArgumentError)
   end
 
   it "should allow setting options in a block" do
@@ -29,40 +29,40 @@ end
 describe PBKDF2, "when configuring a hash function" do
   it "should default to SHA256" do
     p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000)
-    p.hash_function.name.should == "SHA256"
+    expect(p.hash_function.name).to eq("SHA256")
   end
 
   it "should support at least SHA1, SHA512, and MD5" do
     %w{SHA1 SHA512 MD5}.each do |alg|
       p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :hash_function=>alg)
-      p.hash_function.name.should == alg
+      expect(p.hash_function.name).to eq(alg)
     end
   end
 
   it "should allow setting by symbols" do
     p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :hash_function=>:sha512)
-    p.hash_function.name.should == "SHA512"
+    expect(p.hash_function.name).to eq("SHA512")
   end
 
   it "should allow setting by strings" do
     p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :hash_function=>"sha512")
-    p.hash_function.name.should == "SHA512"
+    expect(p.hash_function.name).to eq("SHA512")
   end
 
   it "should allow setting by PKCS-style 'hmacWith' strings" do
     p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :hash_function=>"hmacWithSHA512")
-    p.hash_function.name.should == "SHA512"
+    expect(p.hash_function.name).to eq("SHA512")
   end
 
   it "should allow setting by classes in OpenSSL::Digest" do
     p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :hash_function=>OpenSSL::Digest::SHA512)
-    p.hash_function.name.should == "SHA512"
+    expect(p.hash_function.name).to eq("SHA512")
   end
 
   it "should allow setting by an instantiated object of type OpenSSL::Digest::Digest" do
     hfunc = OpenSSL::Digest::SHA512.new
     p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :hash_function=>hfunc)
-    p.hash_function.name.should == "SHA512"
+    expect(p.hash_function.name).to eq("SHA512")
   end
 end
 
@@ -70,31 +70,31 @@ describe PBKDF2, "when setting a key length" do
   it "should default to the size of the hash function used" do
     %w{SHA1 SHA512 MD5}.each do |alg|
       p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :hash_function=>alg)
-      p.key_length.should == OpenSSL::Digest::Digest.new(alg).size
+      expect(p.key_length).to eq(OpenSSL::Digest::Digest.new(alg).size)
     end
   end
 
   it "should throw an ArgumentError if a negative length is set" do
-    lambda {p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :key_length=>-1)}.should  raise_error(ArgumentError)
+    expect {p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1000, :key_length=>-1)}.to  raise_error(ArgumentError)
   end
 
   it "should throw an ArgumentError if too long a length is set" do
     not_too_long = ((2**32 - 1) * OpenSSL::Digest::SHA256.new.size)
     too_long = not_too_long + 1
-    lambda {p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1, :key_length=>not_too_long, :hash_function=>:sha256)}.should_not raise_error
-    lambda {p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1, :key_length=>too_long, :hash_function=>:sha256)}.should raise_error(ArgumentError)
+    expect {p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1, :key_length=>not_too_long, :hash_function=>:sha256)}.not_to raise_error
+    expect {p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1, :key_length=>too_long, :hash_function=>:sha256)}.to raise_error(ArgumentError)
   end
 
   it "should ensure that the derived key really is that long" do
     length = 123
     p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>1, :key_length=>length)
-    p.bin_string.length.should == length
+    expect(p.bin_string.length).to eq(length)
   end
 end
 
 describe PBKDF2, "when setting the number of iterations" do
   it "should throw an ArgumentError if a number less than 1 is passed" do
-    lambda {p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>0)}.should  raise_error(ArgumentError)
+    expect {p = PBKDF2.new(:password=>"s33krit", :salt=>"nacl", :iterations=>0)}.to  raise_error(ArgumentError)
   end
 end
 
@@ -114,31 +114,31 @@ describe PBKDF2, "once created" do
       x.salt = "nacl"
       x.iterations = 1
     end
-    @p.hex_string.should == q.hex_string
+    expect(@p.hex_string).to eq(q.hex_string)
   end
 
   it "should recalculate the value if the password changes" do
     @p.password = "foo"
-    @p.hex_string.should_not == @val
+    expect(@p.hex_string).not_to eq(@val)
   end
 
   it "should recalculate the value if the salt changes" do
     @p.salt = "foo"
-    @p.hex_string.should_not == @val
+    expect(@p.hex_string).not_to eq(@val)
   end
 
   it "should recalculate the value if the number of iterations changes" do
     @p.iterations = 2
-    @p.hex_string.should_not == @val
+    expect(@p.hex_string).not_to eq(@val)
   end
 
   it "should recalculate the value if the hash function changes" do
     @p.hash_function = :md5
-    @p.hex_string.should_not == @val
+    expect(@p.hex_string).not_to eq(@val)
   end
 
   it "should recalculate the value if the key length changes" do
     @p.key_length = 10
-    @p.hex_string.should_not == @val
+    expect(@p.hex_string).not_to eq(@val)
   end
 end

--- a/spec/rfc3962_spec.rb
+++ b/spec/rfc3962_spec.rb
@@ -21,13 +21,13 @@ describe PBKDF2, "when deriving keys" do
     end
     
     expected = "cd ed b5 28 1b b2 f8 01 56 5a 11 22 b2 56 35 15"
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
     
     expected =  "cd ed b5 28 1b b2 f8 01 56 5a 11 22 b2 56 35 15" +
                 "0a d1 f7 a0 4b b9 f3 a3 33 ec c0 e2 e1 f7 08 37"
     
     p.key_length = 256/8
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
   end
 
   it "should match the second test case in appendix B of RFC 3962" do
@@ -48,12 +48,12 @@ describe PBKDF2, "when deriving keys" do
     end
     
     expected = "01 db ee 7f 4a 9e 24 3e 98 8b 62 c7 3c da 93 5d"
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
     
     expected =  "01 db ee 7f 4a 9e 24 3e 98 8b 62 c7 3c da 93 5d" + 
                 "a0 53 78 b9 32 44 ec 8f 48 a9 9e 61 ad 79 9d 86"
     p.key_length = 256/8
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
   end
 
   it "should match the third test case in appendix B of RFC 3962" do
@@ -74,12 +74,12 @@ describe PBKDF2, "when deriving keys" do
     end
     
     expected = "5c 08 eb 61 fd f7 1e 4e 4e c3 cf 6b a1 f5 51 2b"
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
     
     expected =  "5c 08 eb 61 fd f7 1e 4e 4e c3 cf 6b a1 f5 51 2b" +
                 "a7 e5 2d db c5 e5 14 2f 70 8a 31 e2 e6 2b 1e 13"
     p.key_length = 256/8
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
   end
 
   it "should match the fourth test case in appendix B of RFC 3962" do
@@ -100,12 +100,12 @@ describe PBKDF2, "when deriving keys" do
     end
     
     expected = "d1 da a7 86 15 f2 87 e6 a1 c8 b1 20 d7 06 2a 49"
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
     
     expected =  "d1 da a7 86 15 f2 87 e6 a1 c8 b1 20 d7 06 2a 49" +
                 "3f 98 d2 03 e6 be 49 a6 ad f4 fa 57 4b 6e 64 ee"
     p.key_length = 256/8
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
   end
 
   it "should match the fifth test case in appendix B of RFC 3962" do
@@ -127,12 +127,12 @@ describe PBKDF2, "when deriving keys" do
     end
     
     expected = "13 9c 30 c0 96 6b c3 2b a5 5f db f2 12 53 0a c9"
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
     
     expected =  "13 9c 30 c0 96 6b c3 2b a5 5f db f2 12 53 0a c9" +
                 "c5 ec 59 f1 a4 52 f5 cc 9a d9 40 fe a0 59 8e d1"
     p.key_length = 256/8
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
   end
   
   it "should match the sixth test case in appendix B of RFC 3962" do
@@ -154,12 +154,12 @@ describe PBKDF2, "when deriving keys" do
     end
     
     expected = "9c ca d6 d4 68 77 0c d5 1b 10 e6 a6 87 21 be 61"
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
     
     expected =  "9c ca d6 d4 68 77 0c d5 1b 10 e6 a6 87 21 be 61" +
                 "1a 8b 4d 28 26 01 db 3b 36 be 92 46 91 5e c8 2a"
     p.key_length = 256/8
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
   end  
   
   it "should match the seventh test case in appendix B of RFC 3962" do
@@ -185,11 +185,11 @@ describe PBKDF2, "when deriving keys" do
     end
     
     expected = "6b 9c f2 6d 45 45 5a 43 a5 b8 bb 27 6a 40 3b 39"
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
     
     expected =  "6b 9c f2 6d 45 45 5a 43 a5 b8 bb 27 6a 40 3b 39" +
                 "e7 fe 37 a0 c4 1e 02 c2 81 ff 30 69 e1 e9 4f 52"
     p.key_length = 256/8
-    p.hex_string.should == expected.gsub(' ','')
+    expect(p.hex_string).to eq(expected.gsub(' ',''))
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 2.3.6 with the following command:
    transpec -f
- 29 conversions
  from: == expected
    to: eq(expected)
- 24 conversions
  from: obj.should
    to: expect(obj).to
- 7 conversions
  from: lambda { }.should
    to: expect { }.to
- 5 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 1 conversion
  from: lambda { }.should_not
    to: expect { }.not_to

For more details: https://github.com/yujinakayama/transpec#supported-conversions
